### PR TITLE
Force default asn1 encoding to be utf8 rather than ascii

### DIFF
--- a/PyZ3950/asn1.py
+++ b/PyZ3950/asn1.py
@@ -352,7 +352,7 @@ class CtxBase:
     def get_codec (self, base_tag):
         def default_enc (x):
             if isinstance (x, str):
-                return (x.encode ('ascii'), 0)
+                return (x.encode ('utf-8'), 0)
             elif isinstance (x, str):
                 return (x.encode ('utf-8'), 0)
             return (x, 0)


### PR DESCRIPTION
as this allows non-ascii data to be sent through